### PR TITLE
Add support for finding rosrun deps in launch files.

### DIFF
--- a/src/roscompile/launch.py
+++ b/src/roscompile/launch.py
@@ -23,7 +23,11 @@ class Launch:
         
     def get_misc_pkgs(self):
         s = set()
-        for x in re.finditer('\$\(find ([^\)]*)\)', self.tree.toxml()):
+        xml_str = self.tree.toxml()
+        for x in re.finditer('\$\(find ([^\)]*)\)', xml_str):
+            s.add(x.group(1))
+        # rosrun PKG (e.g. <param command="rosrun xacro xacro.py xacrofile.xacro" />
+        for x in re.finditer('rosrun\s+(\w+)\s', xml_str):
             s.add(x.group(1))
         return s
 


### PR DESCRIPTION
I've been working on nearly the same tool you have. Here's an additional regex check that finds runtime dependencies in launchfiles that use rosrun to load parameters.