### PR TITLE
Check out-of-bounds when counting trailing whitespaces

### DIFF
--- a/src/roscompile/package_xml.py
+++ b/src/roscompile/package_xml.py
@@ -39,7 +39,7 @@ def get_sort_key(node, alphabetize_depends=True):
         
 def count_trailing_spaces(s):
     c = 0
-    while s[-c-1]==' ':
+    while c < len(s) and s[-c-1]==' ':
         c += 1
     return c
 


### PR DESCRIPTION
In case of empty strings or strings consisting of only spaces, we need
to make sure we do not go out-of-bounds.