### PR TITLE
Bugfix/roslaunch and more

### DIFF
--- a/src/roscompile/launch.py
+++ b/src/roscompile/launch.py
@@ -1,12 +1,17 @@
 from xml.dom.minidom import parse
+from xml.parsers.expat import ExpatError
 import re
 
 class Launch:
     def __init__(self, fn):
         self.fn = fn
-        self.tree = parse(fn)
-        self.test = len(self.tree.getElementsByTagName('test')) > 0
-        self.valid = len(self.tree.getElementsByTagName('launch')) > 0
+        try:
+            self.tree = parse(fn)
+            self.test = len(self.tree.getElementsByTagName('test')) > 0
+            self.valid = len(self.tree.getElementsByTagName('launch')) > 0
+        except ExpatError: # this is an invalid xml file
+            self.test = False
+            self.valid = False
 
     def get_node_pkgs(self):
         s = set()

--- a/src/roscompile/package.py
+++ b/src/roscompile/package.py
@@ -61,7 +61,7 @@ class Package:
                 if ext_match:
                     data[ext_match].append(full)
                 elif ext == '.launch':
-                    data['launch'].append(Launch(full))
+                    data['launch'].append(full)
                 elif ext in SIMPLE:
                     name = ext[1:]
                     data[name].append(full)
@@ -81,10 +81,12 @@ class Package:
                         continue
                     if ext == '.xml':
                         # Try to make it a launch
-                        launch = Launch(full)
-                        if launch.valid:
-                            data['launch'].append(launch)
-                            continue
+                        try:
+                            if Launch(full).valid:
+                                data['launch'].append(full)
+                                continue
+                        except: # This way we can catch errors on ill-formatted xml files
+                            pass
 
                     with open(full) as f:
                         l = f.readline()
@@ -127,7 +129,8 @@ class Package:
 
     def get_run_dependencies(self):
         packages = set()
-        for launch in self.files['launch']:
+        for launchf in self.files['launch']:
+            launch = Launch(launchf)
             if launch.test:
                 continue
             packages.update(launch.get_dependencies())
@@ -141,7 +144,8 @@ class Package:
             if 'test' not in source.tags:
                 continue
             packages.update(source.get_dependencies())
-        for launch in self.files['launch']:
+        for launchf in self.files['launch']:
+            launch = Launch(launchf)
             if not launch.test:
                 continue
             packages.update(launch.get_dependencies())

--- a/src/roscompile/package.py
+++ b/src/roscompile/package.py
@@ -81,13 +81,10 @@ class Package:
                         continue
                     if ext == '.xml':
                         # Try to make it a launch
-                        try:
-                            if Launch(full).valid:
-                                data['launch'].append(full)
-                                continue
-                        except: # This way we can catch errors on ill-formatted xml files
-                            pass
-
+                        if Launch(full).valid:
+                            data['launch'].append(full)
+                            continue
+                
                     with open(full) as f:
                         l = f.readline()
                         if '#!' in l and 'python' in l:

--- a/src/roscompile/util.py
+++ b/src/roscompile/util.py
@@ -3,15 +3,15 @@ import re
 HASH_PATTERN = re.compile('\n#+\n')
 
 def get_ignore_data_helper(basename):
-    #try:
+    try:
         fn = 'package://roscompile/data/' + basename + '.ignore'
         lines = []
-        for s in get(fn).read().split('\n'):
+        for s in get(fn).split('\n'):
             if len(s) > 0:
                 lines.append(s + '\n')
         return lines
-    #except:
-    #    return []
+    except:
+        return []
 
 def get_ignore_data(name):
     return get_ignore_data_helper(name), get_ignore_data_helper(name + '_patterns')

--- a/src/roscompile/util.py
+++ b/src/roscompile/util.py
@@ -3,15 +3,12 @@ import re
 HASH_PATTERN = re.compile('\n#+\n')
 
 def get_ignore_data_helper(basename):
-    try:
-        fn = 'package://roscompile/data/' + basename + '.ignore'
-        lines = []
-        for s in get(fn).split('\n'):
-            if len(s) > 0:
-                lines.append(s + '\n')
-        return lines
-    except:
-        return []
+    fn = 'package://roscompile/data/' + basename + '.ignore'
+    lines = []
+    for s in get(fn).split('\n'):
+        if len(s) > 0:
+            lines.append(s + '\n')
+    return lines
 
 def get_ignore_data(name):
     return get_ignore_data_helper(name), get_ignore_data_helper(name + '_patterns')


### PR DESCRIPTION
This fixes a few bugs I ran into when using roscompile with all options enabled. 

I would recommend adding unit tests using some example data to avoid regressions. This would have probably avoided the first 2 of these bugs.

Store roslaunch files as strings too to avoid crashes further-up in code
======================================

In case you enable `check_misc_installs`, you would run into issue. It is assumed in the code that all values in the `data` dict are strings. However, it seems someone wanted to do more fancy things with roslaunch files and stored it as a launch object instead. This causes other code to crash with certain options (like `check_misc_installs`) enabled. I've chosen to keep everything in the `data` dict as strings again, and only shortly turn those files into launch objects when needed. 

Removing dumb comments crashed
================================

The options `remove_dumb_cmake_comments`, and `remove_dumb_package_comments` both caused crashes. In `src/roscompile/util.py`, the `get(fn)` (from `from resource_retriever import get`) call in `def get_ignore_data_helper(basename)` returns a string immediately, so there is no need to have a `read` call on it. I changed that, and it turned out that (commented) the try/catch would also never be needed, so I removed that too.

Dealing with invalid XMLs
======================

When reading an 'invalid' xml file, the whole roscompile pkg would crash. I fixed this ine "src/roscompile/launch.py". We had files that repeatedly used the same block, without using attributes like `name=...` to make the blocks unique. Apparently these are considered invalid by the used xml library, raising an exception and crashing all of roscompile. That exception is now caught and it returns an launch object static that it is not a valid roslaunch xml.

This is an example 'invalid' xml file, which would make roscompile crash:

```xml
<foo>
   <bar>hello</bar>
</foo>
<foo>
  <bar2>bye</bar2>
</foo>
```
