### PR TITLE
resolve variables on executable returns

### DIFF
--- a/src/roscompile/cmake.py
+++ b/src/roscompile/cmake.py
@@ -374,7 +374,8 @@ class CMake:
         lib_src = set()
         for cmd in self.content_map[tagname]:
             tokens = cmd.get_tokens()
-            lib_src.update(tokens[1:])
+            tokens_correct = [self.resolve_variables(s) for s in tokens]
+            lib_src.update(tokens_correct[1:])
         return lib_src
 
     def get_library_source(self):


### PR DESCRIPTION
Initially, when invoking roscompile I got an error as I used ${PROJECT_NAME}_node.cpp in my executable sources, which is on the other hand suggested by catkin_lint.

This little change change resolves this at runtime.