### PR TITLE
Grab Bag of New Features/Bug Fixes

### DIFF
--- a/ros_introspection/CMakeLists.txt
+++ b/ros_introspection/CMakeLists.txt
@@ -1,13 +1,16 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ros_introspection)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS rosmsg)
 catkin_python_setup()
 
-catkin_package()
+catkin_package(
+    CATKIN_DEPENDS rosmsg
+)
 
 if (CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS roslint)
   roslint_python()
   roslint_add_test()
 endif()
+catkin_install_python(PROGRAMS scripts/print_packages.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/ros_introspection/package.xml
+++ b/ros_introspection/package.xml
@@ -9,8 +9,10 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <exec_depend>rosmsg</exec_depend>
+  <depend>rosmsg</depend>
   <exec_depend>python-requests</exec_depend>
+  <exec_depend>python-rospkg</exec_depend>
+  <exec_depend>python-yaml</exec_depend>
   <test_depend>roslint</test_depend>
 
 </package>

--- a/ros_introspection/src/ros_introspection/cmake.py
+++ b/ros_introspection/src/ros_introspection/cmake.py
@@ -11,7 +11,7 @@ ORDERING = ['cmake_minimum_required', 'project', 'set_directory_properties', 'fi
             'add_message_files', 'add_service_files', 'add_action_files',
             'generate_dynamic_reconfigure_options', 'generate_messages', 'catkin_package', 'catkin_metapackage',
             BUILD_TARGET_COMMANDS + ['include_directories'],
-            ['roslint_cpp', 'roslint_python', 'roslint_add_test'],
+            ['catkin_download_test_data', 'roslint_cpp', 'roslint_python', 'roslint_add_test', 'catkin_add_nosetests'],
             'catkin_add_gtest', 'group',
             ['install', 'catkin_install_python']]
 

--- a/ros_introspection/src/ros_introspection/cmake.py
+++ b/ros_introspection/src/ros_introspection/cmake.py
@@ -1,4 +1,8 @@
 import collections
+import re
+
+VARIABLE_PATTERN = re.compile(r'\$\{([^\}]+)\}')
+QUOTED_PATTERN = re.compile(r'"([^"]+)"')
 
 BUILD_TARGET_COMMANDS = ['add_library', 'add_executable', 'add_rostest', 'add_dependencies', 'target_link_libraries']
 
@@ -125,9 +129,11 @@ class Command:
         if len(self.sections) == 1 and type(self.sections[0]) == str:
             self.sections = []
 
-    def get_tokens(self):
+    def get_tokens(self, include_name=False):
         tokens = []
         for section in self.get_real_sections():
+            if include_name and section.name:
+                tokens.append(section.name)
             tokens += section.values
         return tokens
 
@@ -180,17 +186,39 @@ class CMake:
                 self.content_map['group'].append(content)
         self.depth = depth
 
+        self.variables = {}
+        for cmd in self.content_map['set']:
+            tokens = cmd.get_tokens(include_name=True)
+            self.variables[tokens[0]] = ' '.join(tokens[1:])
+        self.variables['PROJECT_NAME'] = self.get_project_name()
+
     def get_project_name(self):
         project_tags = self.content_map['project']
         if not project_tags:
             return ''
-        return project_tags[0].get_tokens()[0]
+        # Get all tokens just in case the name is all caps
+        return project_tags[0].get_tokens(include_name=True)[0]
 
     def resolve_variables(self, s):
-        VARS = {'${PROJECT_NAME}': self.get_project_name()}
-        for k, v in VARS.iteritems():
-            s = s.replace(k, v)
+        m = VARIABLE_PATTERN.search(s)
+        if not m:
+            return s
+
+        for k, v in self.variables.iteritems():
+            s = s.replace('${%s}' % k, v)
         return s
+
+    def get_resolved_tokens(self, cmd, include_name=False):
+        tokens = []
+        for token in cmd.get_tokens(include_name):
+            if token and token[0] == '#':
+                continue
+            m = QUOTED_PATTERN.match(token)
+            if m:
+                token = m.group(1)
+            token = self.resolve_variables(token)
+            tokens += token.split(' ')
+        return tokens
 
     def get_insertion_index(self, cmd):
         anchors = self.get_ordered_build_targets()
@@ -239,12 +267,18 @@ class CMake:
         for cmd in cmds:
             self.remove_command(cmd)
 
-    def get_source_build_rules(self, tag):
+    def get_source_build_rules(self, tag, resolve_target_name=False):
         rules = {}
         for cmd in self.content_map[tag]:
-            tokens = [self.resolve_variables(s) for s in cmd.get_tokens()]
-            target = tokens[0]
-            deps = tokens[1:]
+            resolved_tokens = self.get_resolved_tokens(cmd, True)
+
+            if resolve_target_name:
+                target = resolved_tokens[0]
+            else:
+                tokens = cmd.get_tokens(True)
+                target = tokens[0]
+
+            deps = resolved_tokens[1:]
             rules[target] = deps
         return rules
 

--- a/ros_introspection/src/ros_introspection/cmake_parser.py
+++ b/ros_introspection/src/ros_introspection/cmake_parser.py
@@ -108,6 +108,7 @@ class AwesomeParser:
             cmd.pre_paren += s
             original += s
         original += self.match('left paren')
+        paren_depth = 1
 
         while len(self.tokens) > 0:
             typ = self.next_real_type()
@@ -119,10 +120,12 @@ class AwesomeParser:
                 typ, tok_contents = self.tokens.pop(0)
                 original += tok_contents
                 if typ == 'right paren':
-                    cmd.original = original
-                    return cmd
+                    paren_depth -= 1
+                    if paren_depth == 0:
+                        cmd.original = original
+                        return cmd
                 elif typ == 'left paren':
-                    pass
+                    paren_depth += 1
                 else:
                     cmd.sections.append(tok_contents)
         raise CMakeParseError('File ended while processing command "%s"' % (command_name))
@@ -150,7 +153,7 @@ class AwesomeParser:
 
         delims = set()
         current = ''
-        while self.next_real_type() not in ['right paren', 'caps']:
+        while self.next_real_type() not in ['left paren', 'right paren', 'caps']:
             typ = self.get_type()
             if typ in ALL_WHITESPACE:
                 token = self.match()

--- a/ros_introspection/src/ros_introspection/cmake_parser.py
+++ b/ros_introspection/src/ros_introspection/cmake_parser.py
@@ -182,10 +182,10 @@ class AwesomeParser:
             # print '[%s]%s'%(typ, repr(tok))
             return tok
         else:
-            sys.stderr.write('Expected type "%s" but got "%s"\n' % (typ, self.get_type()))
+            sys.stderr.write('Token Dump:\n')
             for a in self.tokens:
                 sys.stderr.write(str(a) + '\n')
-            exit(-1)
+            raise CMakeParseError('Expected type "%s" but got "%s"' % (typ, self.get_type()))
 
     def get_type(self):
         if len(self.tokens) > 0:

--- a/ros_introspection/src/ros_introspection/package.py
+++ b/ros_introspection/src/ros_introspection/package.py
@@ -47,7 +47,6 @@ class Package:
                 continue
             packages.update(launch.get_dependencies())
 
-        packages.update(self.source_code.get_external_python_dependencies())
         if self.name in packages:
             packages.remove(self.name)
         return packages

--- a/ros_introspection/src/ros_introspection/package_xml.py
+++ b/ros_introspection/src/ros_introspection/package_xml.py
@@ -49,6 +49,7 @@ class PackageXML:
         self._name = None
         self._format = None
         self._std_tab = None
+        self.changed = False
 
     @property
     def name(self):
@@ -199,6 +200,7 @@ class PackageXML:
         before = self.root.childNodes[:index + 1]
         after = self.root.childNodes[index + 1:]
         self.root.childNodes = before + [self.get_tab_element(), tag] + after
+        self.changed = True
 
     def insert_new_tags(self, tags):
         for tag in tags:
@@ -213,6 +215,7 @@ class PackageXML:
             parent.childNodes = all_elements + [self.get_tab_element()]
         else:
             parent.childNodes = parent.childNodes[:-1] + all_elements + parent.childNodes[-1:]
+        self.changed = True
 
     def insert_new_packages(self, tag, values):
         for pkg in sorted(values):
@@ -254,6 +257,7 @@ class PackageXML:
             if previous.nodeType == previous.TEXT_NODE and INDENT_PATTERN.match(previous.nodeValue):
                 parent.removeChild(previous)
         parent.removeChild(element)
+        self.changed = True
 
     def remove_dependencies(self, name, pkgs, quiet=False):
         for el in self.root.getElementsByTagName(name):
@@ -286,6 +290,7 @@ class PackageXML:
                 if target_email:
                     el.setAttribute('email', target_email)
                 print '\tReplacing %s %s/%s with %s/%s' % (el.nodeName, name, email, target_name, target_email)
+                self.changed = True
 
     def get_license_element(self):
         els = self.root.getElementsByTagName('license')
@@ -299,7 +304,9 @@ class PackageXML:
 
     def set_license(self, license):
         el = self.get_license_element()
-        el.childNodes[0].nodeValue = license
+        if license != el.childNodes[0].nodeValue:
+            el.childNodes[0].nodeValue = license
+            self.changed = True
 
     def is_metapackage(self):
         for node in self.root.getElementsByTagName('export'):
@@ -350,13 +357,12 @@ class PackageXML:
         if new_fn is None:
             new_fn = self.fn
 
+        if new_fn == self.fn and not self.changed:
+            return
+
         s = self.tree.toxml(self.tree.encoding)
         index = get_package_tag_index(s)
         s = self.header + s[index:]
-
-        old_s = open(new_fn, 'r').read().decode('UTF-8')
-        if old_s.strip() == s:
-            return
 
         with open(new_fn, 'w') as f:
             f.write(s.encode('UTF-8'))

--- a/ros_introspection/src/ros_introspection/package_xml.py
+++ b/ros_introspection/src/ros_introspection/package_xml.py
@@ -235,7 +235,14 @@ class PackageXML:
             self.insert_new_packages('build_depend', build_depends)
             self.insert_new_packages('run_depend', run_depends)
         elif prefer_depend_tag:
-            self.insert_new_packages('depend', build_depends.union(run_depends))
+            depend_tags = build_depends.union(run_depends)
+
+            # Remove tags that overlap with new depends
+            self.remove_dependencies('build_depend', existing_build.intersection(depend_tags))
+            self.remove_dependencies('exec_depend', existing_run.intersection(depend_tags))
+
+            # Insert depends
+            self.insert_new_packages('depend', depend_tags)
         else:
             both = build_depends.intersection(run_depends)
             self.insert_new_packages('depend', both)

--- a/ros_introspection/src/ros_introspection/ros_generator.py
+++ b/ros_introspection/src/ros_introspection/ros_generator.py
@@ -1,7 +1,7 @@
 import os.path
 import re
 
-AT_LEAST_THREE_DASHES = re.compile('^\-{3,}$')
+AT_LEAST_THREE_DASHES = re.compile('^\-{3,}\r?$')
 FIELD_LINE = re.compile('([\w_/]+)(\[\d*\])?\s+([\w_]+)\s*(=.*)?(\s*\#.*)?$', re.DOTALL)
 
 
@@ -30,7 +30,8 @@ class GeneratorSection:
         self.fields = []
 
     def add_line(self, line):
-        if line[0] == '#' or line == '\n':
+        stripped = line.strip()
+        if not stripped or stripped[0] == '#':
             self.contents.append(line)
             return
         m = FIELD_LINE.match(line)

--- a/ros_introspection/src/ros_introspection/ros_generator.py
+++ b/ros_introspection/src/ros_introspection/ros_generator.py
@@ -44,8 +44,7 @@ class GeneratorSection:
             else:
                 self.contents.append('\n')
         else:
-            print repr(line)
-            exit(0)
+            raise Exception('Unable to parse generator line: ' + repr(line))
 
     def __repr__(self):
         return ''.join(map(str, self.contents))

--- a/ros_introspection/src/ros_introspection/util.py
+++ b/ros_introspection/src/ros_introspection/util.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import traceback
 from package import Package
 
 
@@ -9,7 +11,11 @@ def get_packages(root_fn='.', create_objects=True):
             continue
         if 'package.xml' in files:
             if create_objects:
-                packages.append(Package(root))
+                try:
+                    packages.append(Package(root))
+                except:
+                    sys.stderr.write('ERROR: Trouble parsing package @ %s\n' % root)
+                    sys.stderr.write(traceback.format_exc())
             else:
                 packages.append(root)
     return packages

--- a/roscompile/CMakeLists.txt
+++ b/roscompile/CMakeLists.txt
@@ -25,7 +25,9 @@ if(CATKIN_ENABLE_TESTING)
   roslint_add_test()
 endif()
 
-catkin_install_python(PROGRAMS scripts/roscompile scripts/add_tests scripts/convert_to_format_2
+catkin_install_python(PROGRAMS scripts/roscompile scripts/add_tests scripts/convert_to_format_2 scripts/add_compile_options scripts/roscompile_command
                       DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-install(FILES data/cmake.ignore data/cmake_patterns.ignore data/package.ignore data/package_patterns.ignore DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/data)
+install(FILES data/cmake.ignore data/cmake_patterns.ignore data/package.ignore data/package_patterns.ignore
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/data
+)

--- a/roscompile/README.md
+++ b/roscompile/README.md
@@ -24,6 +24,7 @@ There are also some other useful scripts described at the bottom of this documen
  * `update_people` - Reads the &lt;author> and &lt;maintainer> tags and allows you to programmatically replace them. (i.e. 'dlu', 'Dave Lu', 'David Lu'', 'dlu@TODO' can all become 'David V. Lu!!') (see configuration section below)
  * `update_license` - Updates TODO licenses to a configurable default license (see configuration section below)
  * `update_metapackage` - Update your metapackage dependencies
+ * `misc_xml_formatting` - Remove extra whitespace from inside tags in package.xml (and plugin xmls)
 
 ## CMakeLists.txt
  * `check_generators` - Automatically looks for `msg`/`srv`/`action`/`dynamic_reconfigure` definitions and ensures they are properly built in the `CMakeLists.txt`

--- a/roscompile/README.md
+++ b/roscompile/README.md
@@ -12,6 +12,7 @@ There are also some other useful scripts described at the bottom of this documen
 ## Dependencies
  * Checks for dependencies by looking in the source code, message, service, action and launch files.
  * `check_manifest_dependencies` - Inserts build/run/test dependencies into your `package.xml`
+ * `check_python_dependencies` - Inserts run dependencies for external Python libraries
  * `check_cmake_dependencies` - Inserts dependencies into your `CMakeLists.txt` (in both the `find_package` and `catkin_package` commands)
 
 ## package.xml

--- a/roscompile/README.md
+++ b/roscompile/README.md
@@ -43,6 +43,7 @@ There are also some other useful scripts described at the bottom of this documen
  * `update_cplusplus_installs` - Checks for install commands for C++ executables/libraries/header files
  * `update_python_installs` - Checks for install commands for Python executables
  * `update_misc_installs` - Checks for install commands for launch files, plugin configurations and other non-code files.
+ * `fix_double_directory_installs` - Checks to make sure directory installs don't use the name of the directory twice, a la `$INSTALL_LOCATION/launch/launch/whatever.launch`
 
 ## C++
  * Examines the `add_library` and `add_executable` commands in the `CMakeLists.txt` and ensures that each is matched with the appropriate catkin variables.

--- a/roscompile/package.xml
+++ b/roscompile/package.xml
@@ -11,9 +11,12 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>catkin</depend>
   <depend>ros_introspection</depend>
-  <test_depend>roslint</test_depend>
+  <exec_depend>python-argparse</exec_depend>
+  <exec_depend>python-rospkg</exec_depend>
+  <exec_depend>python-yaml</exec_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>pluginlib</test_depend>
+  <test_depend>roslint</test_depend>
   <test_depend>tf</test_depend>
 
 </package>

--- a/roscompile/scripts/add_tests
+++ b/roscompile/scripts/add_tests
@@ -4,6 +4,7 @@ from ros_introspection.util import get_packages
 from ros_introspection.cmake import Command
 from roscompile.cmake import check_cmake_dependencies_helper
 import argparse
+import os
 
 
 def add_test_command(test_section, cmd_name, values=None):
@@ -52,8 +53,24 @@ for package in pkgs:
         # TODO: Assumes that the launch files are in the launch folder
 
     if args.lint:
-        if package.source_code.get_source_by_language('python'):
-            add_test_command(test_section, 'roslint_python')
+        python_source = package.source_code.get_source_by_language('python')
+        if python_source:
+            # Split into two sections, things with the .py extension and those without
+            py_extension = []
+            without = []
+
+            for src in python_source:
+                fn = src.rel_fn
+                ext = os.path.splitext(fn)[-1]
+                if ext == '.py':
+                    py_extension.append(fn)
+                else:
+                    without.append(fn)
+
+            if py_extension:
+                add_test_command(test_section, 'roslint_python')
+            if without:
+                add_test_command(test_section, 'roslint_python', without)
 
         if package.source_code.get_source_by_language('c++'):
             add_test_command(test_section, 'roslint_cpp')

--- a/roscompile/src/roscompile/cmake.py
+++ b/roscompile/src/roscompile/cmake.py
@@ -40,9 +40,17 @@ def check_cmake_dependencies(package):
 
 
 def get_matching_add_depends(cmake, search_target):
+    valid_targets = set([search_target])
+    alt_target = cmake.resolve_variables(search_target)
+    if alt_target != search_target:
+        valid_targets.add(alt_target)
+
     for cmd in cmake.content_map['add_dependencies']:
         target = cmd.first_token()
-        if target == search_target:
+        if target in valid_targets:
+            return cmd
+        resolved_target = cmake.resolve_variables(target)
+        if resolved_target in valid_targets:
             return cmd
 
 

--- a/roscompile/src/roscompile/installs.py
+++ b/roscompile/src/roscompile/installs.py
@@ -147,6 +147,7 @@ def install_section_check(cmake, items, install_type, directory=False, subfolder
         return
 
     cmd = None
+    items = [os.path.join(subfolder, item) for item in items]
     for cmd in cmds:
         install_sections(cmd, destination_map, subfolder)
         section = cmd.get_section(section_name)

--- a/roscompile/src/roscompile/installs.py
+++ b/roscompile/src/roscompile/installs.py
@@ -203,3 +203,22 @@ def update_misc_installs(package):
 
     for folder, files in extra_files_by_folder.iteritems():
         install_section_check(package.cmake, files, 'misc', subfolder=folder)
+
+
+@roscompile
+def fix_double_directory_installs(package):
+    for cmd in package.cmake.content_map['install']:
+        dir_section = cmd.get_section('DIRECTORY')
+        dest_sections = cmd.get_sections('DESTINATION')
+
+        if not dir_section or not dest_sections:
+            continue
+        directory = dir_section.values[0]
+        final_slash = directory[-1] == '/'
+
+        for section in dest_sections:
+            destination = section.values[0]
+            if not final_slash and destination.endswith(directory):
+                # Remove double directory and final slash
+                section.values[0] = destination[:-len(directory) - 1]
+                cmd.changed = True

--- a/roscompile/src/roscompile/manifest.py
+++ b/roscompile/src/roscompile/manifest.py
@@ -27,6 +27,12 @@ def check_manifest_dependencies(package):
                 package.manifest.insert_new_packages(tag, [msg_pkg])
 
 
+@roscompile
+def check_python_dependencies(package):
+    run_depends = package.source_code.get_external_python_dependencies()
+    package.manifest.add_packages(set(), run_depends, prefer_depend_tag=False)
+
+
 def has_element_child(node):
     for child in node.childNodes:
         if child.nodeType == child.ELEMENT_NODE:

--- a/roscompile/src/roscompile/manifest.py
+++ b/roscompile/src/roscompile/manifest.py
@@ -246,6 +246,7 @@ def remove_empty_manifest_lines(package):
     if remove_empty_lines_helper(package.manifest.root):
         package.manifest.changed = True
 
+
 @roscompile
 def update_people(package, config=None):
     if config is None:

--- a/roscompile/src/roscompile/misc.py
+++ b/roscompile/src/roscompile/misc.py
@@ -66,4 +66,3 @@ def misc_xml_formatting(package):
     package.manifest.changed = True
     for config in package.plugin_configs:
         config.changed = True
-

--- a/roscompile/src/roscompile/misc.py
+++ b/roscompile/src/roscompile/misc.py
@@ -66,3 +66,4 @@ def misc_xml_formatting(package):
     package.manifest.changed = True
     for config in package.plugin_configs:
         config.changed = True
+

--- a/roscompile/src/roscompile/misc.py
+++ b/roscompile/src/roscompile/misc.py
@@ -59,3 +59,10 @@ def update_metapackage(package, require_matching_name=False):
 
     package.manifest.remove_dependencies(pkg_type, existing_sub_packages - sub_packages)
     package.cmake.section_check([], 'catkin_metapackage', zero_okay=True)
+
+
+@roscompile
+def misc_xml_formatting(package):
+    package.manifest.changed = True
+    for config in package.plugin_configs:
+        config.changed = True

--- a/roscompile/test/manual_test.py
+++ b/roscompile/test/manual_test.py
@@ -54,6 +54,7 @@ if __name__ == '__main__':
 
         with cases[test_config['in']] as pkg_in:
             try:
+                total += 1
                 if test_config['in'] == test_config['out']:
                     pkg_out = pkg_in.copy()
                 else:
@@ -73,7 +74,6 @@ if __name__ == '__main__':
                     else:
                         fne(pp)
                 pp.write()
-                total += 1
                 if compare(pkg_in, pkg_out):
                     print '  SUCCESS'
                     successes += 1
@@ -85,5 +85,7 @@ if __name__ == '__main__':
                 print '  EXCEPTION', e.message
                 if args.last:
                     raise
+                if args.fail_once:
+                    break
     if not args.last:
         print '{}/{}'.format(successes, total)


### PR DESCRIPTION
# Bug Fixes
 * Install misc files with the correct relative path
 * Fix msg/srv generator patterns to include some missing corner cases
 * Parse CMake commands with parens in them
 * Track whether the package.xml has changed and only write when it does. Avoids needless internal whitespace changes with unrelated commands
 * Fix overlapping depend/build_depend/exec_depend tags

# New Features
 * Move handling of external Python dependencies to its own command `check_python_dependencies` (previously was part of `check_manifest_dependencies`)
 * Improved variable resolution logic
 * Improved exception handling (instead of `exit(0)`)
 * Internal white space changes are now fixed with their own rule `misc_xml_formatting`
 * New command `fix_double_directory_installs`
 * Make sure roslint_python includes all the python code
 * Misc other changes
