### PR TITLE
[ros_introspection] Use str instead of unicode in replace_contents

### DIFF
--- a/ros_introspection/src/ros_introspection/source_code_file.py
+++ b/ros_introspection/src/ros_introspection/source_code_file.py
@@ -43,7 +43,7 @@ class SourceCodeFile:
         self.changed_contents = contents
         try:
             self.lines = map(str.strip, str(contents).split('\n'))
-        except NameError:
+        except (NameError, UnicodeDecodeError):
             # Python3 Case
             self.lines = list(map(str.strip, contents.split('\n')))
 

--- a/ros_introspection/src/ros_introspection/source_code_file.py
+++ b/ros_introspection/src/ros_introspection/source_code_file.py
@@ -42,7 +42,7 @@ class SourceCodeFile:
     def replace_contents(self, contents):
         self.changed_contents = contents
         try:
-            self.lines = map(unicode.strip, unicode(contents).split('\n'))
+            self.lines = map(str.strip, str(contents).split('\n'))
         except NameError:
             # Python3 Case
             self.lines = list(map(str.strip, contents.split('\n')))


### PR DESCRIPTION
ROS Distro : `melodic`, `noetic`

I had the following error when running `magical_ros2_conversion_tool` :

```
'ascii' codec can't decode byte 0xe4
```

Part of it was maybe caused by the fact that the package I am trying to convert has comments with characters that are not part of ASCII. This error is combined with a message from `pylint`:

```
NameError: name 'unicode' is not defined
```

My solution is to replace `unicode` with `str`. Once replaced, the package ws then able to run without any problems.