### PR TITLE
[ros_introspection] Fix NoneType error in remove_element

### DIFF
--- a/ros_introspection/src/ros_introspection/package_xml.py
+++ b/ros_introspection/src/ros_introspection/package_xml.py
@@ -324,12 +324,13 @@ class PackageXML:
     def remove_element(self, element):
         """Remove the given element AND the text element before it if it is just an indentation."""
         parent = element.parentNode
-        index = parent.childNodes.index(element)
-        if index > 0:
-            previous = parent.childNodes[index - 1]
-            if previous.nodeType == previous.TEXT_NODE and INDENT_PATTERN.match(previous.nodeValue):
-                parent.removeChild(previous)
-        parent.removeChild(element)
+        if parent is not None:
+            index = parent.childNodes.index(element)
+            if index > 0:
+                previous = parent.childNodes[index - 1]
+                if previous.nodeType == previous.TEXT_NODE and INDENT_PATTERN.match(previous.nodeValue):
+                    parent.removeChild(previous)
+            parent.removeChild(element)
         self.changed = True
 
     def remove_dependencies(self, name, pkgs, quiet=False):


### PR DESCRIPTION
ROS Distro : `melodic`, `noetic`

I had the following error when trying to run `magical_ros2_conversion_tool` :

```
AttributeError: 'NoneType' object has no attribute 'childNodes'
```

This happened when the tool was removing deprecated dependencies like `tf` and `roscpp` from `package.xml`. I'm not exactly sure why the DOM Element has no parent node when they refer to deprecated dependencies, but my fix avoids removing elements when those Elements have no `parentNode`.